### PR TITLE
Copy header files when building libkeccak.a

### DIFF
--- a/Build/ToTargetMakefile.xsl
+++ b/Build/ToTargetMakefile.xsl
@@ -166,7 +166,7 @@ AR = ar
 
     <xsl:choose>
         <xsl:when test="substring(@name, string-length(@name)-1, 2)='.a'">
-            <xsl:text>&#9;mkdir $(dir $@)/headers
+            <xsl:text>&#9;mkdir -p $(dir $@)/headers
 &#9;cp $(HEADERS) $(dir $@)/headers/
 &#9;$(AR) rcsv $@ $(OBJECTS)
 </xsl:text>

--- a/Build/ToTargetMakefile.xsl
+++ b/Build/ToTargetMakefile.xsl
@@ -167,7 +167,7 @@ AR = ar
     <xsl:choose>
         <xsl:when test="substring(@name, string-length(@name)-1, 2)='.a'">
             <xsl:text>&#9;mkdir -p $(dir $@)/headers
-&#9;cp $(HEADERS) $(dir $@)/headers/
+&#9;cp -f $(HEADERS) $(dir $@)/headers/
 &#9;$(AR) rcsv $@ $(OBJECTS)
 </xsl:text>
         </xsl:when>

--- a/Build/ToTargetMakefile.xsl
+++ b/Build/ToTargetMakefile.xsl
@@ -166,7 +166,9 @@ AR = ar
 
     <xsl:choose>
         <xsl:when test="substring(@name, string-length(@name)-1, 2)='.a'">
-            <xsl:text>&#9;$(AR) rcsv $@ $(OBJECTS)
+            <xsl:text>&#9;mkdir $(dir $@)/headers
+&#9;cp $(HEADERS) $(dir $@)/headers/
+&#9;$(AR) rcsv $@ $(OBJECTS)
 </xsl:text>
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
So,
    `make generic64/libkeccak.a`
copies the corresponding header files to
    `KeccakCodePackage/bin/generic64/headers/`
so they can be portably `#include`d in external projects.

This helps to prevent size and alignment mismatch when a different version of the library is built than was `#include`d in an external project.
