### PR TITLE
Fixed possible printf format string vulnerability

### DIFF
--- a/KeccakSum/KeccakSum.c
+++ b/KeccakSum/KeccakSum.c
@@ -135,10 +135,8 @@ int processFile(const char *fileName, const Specifications *specs, int base64)
             return -1;
         }
     }
-    printf(display);
-    printf("  ");
-    printf(fileName);
-    printf("\n");
+    printf("%s  ", display);
+    printf("%s\n", fileName);
     return 0;
 }
 


### PR DESCRIPTION
This pull requests fixes potential [format string vulnerability](https://en.wikipedia.org/wiki/Uncontrolled_format_string) in KeccakSum `char* filename` and `char *display`. 

On Linux (at least) it is possible to create a filename with exploit in its name, e.g. 
```bash
%s
```


```bash
$ touch %s
$ ./KeccakSum %s
f5wrpOiPgn1hYEVQdgWFPtc7gJP277yI6xpurPpm7yY8  
$ touch %s%s
$ ./KeccakSum %s%s
Segmentation fault (core dumped)
$ touch %x%x%x%x%x%x%x%x%x%x%x
$ ./KeccakSum %x%x%x%x%x%x%x%x%x%x%x 
f5wrpOiPgn1hYEVQdgWFPtc7gJP277yI6xpurPpm7yY8  57b17780257d137002a42b9c7f5045606193803bd7ac6e1aeba9eeb13cafb3c104afa016e
# contents of my RAM. There could be password or private key.
```

And, after patch:

```bash
$ touch %x%x%x
$ ./KeccakSum %x%x%x 
f5wrpOiPgn1hYEVQdgWFPtc7gJP277yI6xpurPpm7yY8  %x%x%x
```