### PR TITLE
uxth needs two parameters

### DIFF
--- a/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-armcc.s
+++ b/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-armcc.s
@@ -93,7 +93,7 @@ _AllocSize      equ 32*2
 
     eor         $d, $a, $b, LSL #1
     eor         $d, $d, $b, LSR #15
-    uxth        $d
+    uxth        $d, $d
     MEND
 
     MACRO

--- a/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-gcc.s
+++ b/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-gcc.s
@@ -90,7 +90,7 @@
 
     eor         \d, \a, \b, LSL #1
     eor         \d, \d, \b, LSR #15
-    uxth        \d
+    uxth        \d, \d
     .endm
 
 .macro    xandnot     resptr, resofs, aa, bb, cc, temp

--- a/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-armcc.s
+++ b/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-armcc.s
@@ -89,7 +89,7 @@ _su     equ 24*2
     rolxor      $d, $a, $b
     eor         $d, $a, $b, LSL #1
     eor         $d, $d, $b, LSR #15
-    uxth        $d
+    uxth        $d, $d
     MEND
 
     MACRO

--- a/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-gcc.s
+++ b/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-gcc.s
@@ -86,7 +86,7 @@
 .macro  rolxor      d, a, b
     eor         \d, \a, \b, LSL #1
     eor         \d, \d, \b, LSR #15
-    uxth        \d
+    uxth        \d, \d
     .endm
 
 .macro  xandnot     resptr, resofs, aa, bb, cc, temp


### PR DESCRIPTION
According to the ARMv7-M architecture reference manual by ARM, the uxth instruction needs two operands. Somebody failed to compile (with gcc) because of this.