### PR TITLE
Correct compiling error in K12, add -K12 cli shortcut in KeccakTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 var/
+__pycache__

--- a/Tests/main.c
+++ b/Tests/main.c
@@ -475,22 +475,22 @@ void testFIPS202()
 void printHelp()
 {
         printf("Usage: KeccakTests command(s), where the commands can be\n");
-        printf("    --help or -h            To display this page\n");
-        printf("    --all or -a             All tests\n");
-        printf("    --SnP or -p             Tests on Keccak-p permutations\n");
-        printf("    --Keccak or -c          Tests on Keccak sponge and duplex\n");
-        printf("    --KeccakSponge          Tests on Keccak sponge\n");
-        printf("    --KeccakDuplex          Tests on Keccak duplex\n");
-        printf("    --KeccakPRG             Tests on KeccakPRG\n");
-        printf("    --FIPS202 or -f         Tests on FIPS202 and ShortMsgKAT generation\n");
-        printf("    --SP800-185             Tests on SP800-185 functions\n");
-        printf("    --Keyak or -y           Tests on the Keyak authentication encryption scheme\n");
-        printf("    --Ketje or -t           Tests on the Ketje authentication encryption scheme\n");
-        printf("    --KangarooTwelve        Tests on KangarooTwelve\n");
+        printf("  --help or -h              To display this page\n");
+        printf("  --all or -a               All tests\n");
+        printf("  --SnP or -p               Tests on Keccak-p permutations\n");
+        printf("  --Keccak or -c            Tests on Keccak sponge and duplex\n");
+        printf("  --KeccakSponge            Tests on Keccak sponge\n");
+        printf("  --KeccakDuplex            Tests on Keccak duplex\n");
+        printf("  --KeccakPRG               Tests on KeccakPRG\n");
+        printf("  --FIPS202 or -f           Tests on FIPS202 and ShortMsgKAT generation\n");
+        printf("  --SP800-185               Tests on SP800-185 functions\n");
+        printf("  --Keyak or -y             Tests on the Keyak authentication encryption scheme\n");
+        printf("  --Ketje or -t             Tests on the Ketje authentication encryption scheme\n");
+        printf("  --KangarooTwelve or -K12  Tests on KangarooTwelve\n");
 #ifdef KeccakReference
-        printf("    --examples or -e        Generation of example files\n");
+        printf("  --examples or -e          Generation of example files\n");
 #else
-        printf("    --speed or -s           Speed measuresments\n");
+        printf("  --speed or -s             Speed measuresments\n");
 #endif
 }
 
@@ -534,7 +534,7 @@ int process(int argc, char* argv[])
             Keyak = 1;
         else if ((strcmp("--Ketje", argv[i]) == 0) || (strcmp("-t", argv[i]) == 0))
             Ketje = 1;
-        else if (strcmp("--KangarooTwelve", argv[i]) == 0)
+        else if ((strcmp("--KangarooTwelve", argv[i]) == 0) || (strcmp("-K12", argv[i]) == 0))
             KangarooTwelve = 1;
         else if (strcmp("--SP800-185", argv[i]) == 0)
             SP800_185 = 1;

--- a/Tests/testKangarooTwelve.c
+++ b/Tests/testKangarooTwelve.c
@@ -16,8 +16,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "KeccakCodePackage.h"
 #include "KangarooTwelve.h"
 
-/*#define OUTPUT */
-/*#define VERBOSE */
+/* #define OUTPUT */
+/* #define VERBOSE */
 
 #define SnP_width               1600
 #define inputByteSize           (80*1024)
@@ -253,7 +253,7 @@ void writeTestKangarooTwelve(const char *filename)
 {
     FILE *f = fopen(filename, "w");
     assert(f != NULL);
-    writeTestKangarooTwelveOne(f, 128);
+    writeTestKangarooTwelveOne(f);
     fclose(f);
 }
 #endif


### PR DESCRIPTION
Solve this compilation error:

    Tests/testKangarooTwelve.c: In function ‘writeTestKangarooTwelve’:
    Tests/testKangarooTwelve.c:256:5: error: too many arguments to function ‘writeTestKangarooTwelveOne’
          writeTestKangarooTwelveOne(f, 128);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~
    Tests/testKangarooTwelve.c:240:6: note: declared here
     void writeTestKangarooTwelveOne(FILE *f)
          ^~~~~~~~~~~~~~~~~~~~~~~~~~