### PR TITLE
Prevent warnings with respect to redefined BitSequence types

### DIFF
--- a/Modes/KeccakHash.c
+++ b/Modes/KeccakHash.c
@@ -34,7 +34,7 @@ HashReturn Keccak_HashInitialize(Keccak_HashInstance *instance, unsigned int rat
 
 /* ---------------------------------------------------------------- */
 
-HashReturn Keccak_HashUpdate(Keccak_HashInstance *instance, const BitSequence *data, DataLength databitlen)
+HashReturn Keccak_HashUpdate(Keccak_HashInstance *instance, const BitSequence *data, BitLength databitlen)
 {
     if ((databitlen % 8) == 0)
         return (HashReturn)KeccakWidth1600_SpongeAbsorb(&instance->sponge, data, databitlen/8);
@@ -72,7 +72,7 @@ HashReturn Keccak_HashFinal(Keccak_HashInstance *instance, BitSequence *hashval)
 
 /* ---------------------------------------------------------------- */
 
-HashReturn Keccak_HashSqueeze(Keccak_HashInstance *instance, BitSequence *data, DataLength databitlen)
+HashReturn Keccak_HashSqueeze(Keccak_HashInstance *instance, BitSequence *data, BitLength databitlen)
 {
     if ((databitlen % 8) != 0)
         return FAIL;

--- a/Modes/KeccakHash.h
+++ b/Modes/KeccakHash.h
@@ -21,8 +21,13 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "KeccakSponge.h"
 #include <string.h>
 
+#ifndef _Keccak_BitTypes_
+#define _Keccak_BitTypes_
 typedef unsigned char BitSequence;
-typedef size_t DataLength;
+
+typedef size_t BitLength;
+#endif
+
 typedef enum { SUCCESS = 0, FAIL = 1, BAD_HASHLEN = 2 } HashReturn;
 
 typedef struct {
@@ -82,7 +87,7 @@ HashReturn Keccak_HashInitialize(Keccak_HashInstance *hashInstance, unsigned int
   * @pre    In the previous call to Keccak_HashUpdate(), databitlen was a multiple of 8.
   * @return SUCCESS if successful, FAIL otherwise.
   */
-HashReturn Keccak_HashUpdate(Keccak_HashInstance *hashInstance, const BitSequence *data, DataLength databitlen);
+HashReturn Keccak_HashUpdate(Keccak_HashInstance *hashInstance, const BitSequence *data, BitLength databitlen);
 
 /**
   * Function to call after all input blocks have been input and to get
@@ -106,7 +111,7 @@ HashReturn Keccak_HashFinal(Keccak_HashInstance *hashInstance, BitSequence *hash
   * @pre    @a databitlen is a multiple of 8.
   * @return SUCCESS if successful, FAIL otherwise.
   */
-HashReturn Keccak_HashSqueeze(Keccak_HashInstance *hashInstance, BitSequence *data, DataLength databitlen);
+HashReturn Keccak_HashSqueeze(Keccak_HashInstance *hashInstance, BitSequence *data, BitLength databitlen);
 
 #endif
 

--- a/Modes/SP800-185.h
+++ b/Modes/SP800-185.h
@@ -22,9 +22,12 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #ifndef KeccakP1600_excluded
 
+#ifndef _Keccak_BitTypes_
+#define _Keccak_BitTypes_
 typedef unsigned char BitSequence;
 
 typedef size_t BitLength;
+#endif
 
 typedef struct {
     KeccakWidth1600_SpongeInstance sponge;

--- a/Standalone/CompactFIPS202/genKAT.c
+++ b/Standalone/CompactFIPS202/genKAT.c
@@ -51,7 +51,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 void Keccak(int rate, int capacity, const unsigned char *input, unsigned long long int inputByteLen, unsigned char delimitedSuffix, unsigned char *output, unsigned long long int outputByteLen);
 
 typedef unsigned char BitSequence;
-typedef size_t DataLength;
+typedef size_t BitLength;
 typedef enum { SUCCESS = 0, FAIL = 1, BAD_HASHLEN = 2 } HashReturn;
 
 #define MAX_MARKER_LEN      50


### PR DESCRIPTION
When compiling with `-Wpedantic` and using both `SimpleFIPS202.h` and `SP800-185.h`, the redefinition of BitSequence triggered a warning. This also makes the name of the relevant length type more consistent.