### PR TITLE
Switch byte order of input in FastLoop_Absorb

### DIFF
--- a/lib/common/brg_endian.h
+++ b/lib/common/brg_endian.h
@@ -140,4 +140,18 @@
 
 #endif
 
+#if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+#define HTOLE64(x) (x)
+#else
+#define HTOLE64(x) (\
+  ((x & 0xff00000000000000ull) >> 56) | \
+  ((x & 0x00ff000000000000ull) >> 40) | \
+  ((x & 0x0000ff0000000000ull) >> 24) | \
+  ((x & 0x000000ff00000000ull) >> 8)  | \
+  ((x & 0x00000000ff000000ull) << 8)  | \
+  ((x & 0x0000000000ff0000ull) << 24) | \
+  ((x & 0x000000000000ff00ull) << 40) | \
+  ((x & 0x00000000000000ffull) << 56))
+#endif
+
 #endif

--- a/lib/common/brg_endian.h
+++ b/lib/common/brg_endian.h
@@ -114,13 +114,14 @@
       defined( __VMS )     || defined( _M_X64 )
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
 
-#elif defined( AMIGA )   || defined( applec )    || defined( __AS400__ )  || \
-      defined( _CRAY )   || defined( __hppa )    || defined( __hp9000 )   || \
-      defined( ibm370 )  || defined( mc68000 )   || defined( m68k )       || \
-      defined( __MRC__ ) || defined( __MVS__ )   || defined( __MWERKS__ ) || \
-      defined( sparc )   || defined( __sparc)    || defined( SYMANTEC_C ) || \
-      defined( __VOS__ ) || defined( __TIGCC__ ) || defined( __TANDEM )   || \
-      defined( THINK_C ) || defined( __VMCMS__ ) || defined( _AIX )
+#elif defined( AMIGA )    || defined( applec )    || defined( __AS400__ )  || \
+      defined( _CRAY )    || defined( __hppa )    || defined( __hp9000 )   || \
+      defined( ibm370 )   || defined( mc68000 )   || defined( m68k )       || \
+      defined( __MRC__ )  || defined( __MVS__ )   || defined( __MWERKS__ ) || \
+      defined( sparc )    || defined( __sparc)    || defined( SYMANTEC_C ) || \
+      defined( __VOS__ )  || defined( __TIGCC__ ) || defined( __TANDEM )   || \
+      defined( THINK_C )  || defined( __VMCMS__ ) || defined( _AIX )       || \
+      defined( __s390__ ) || defined( __s390x__ ) || defined( __zarch__ )
 #  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
 
 #elif defined(__arm__)

--- a/lib/low/KeccakP-1600/Optimized/KeccakP-1600-64.macros
+++ b/lib/low/KeccakP-1600/Optimized/KeccakP-1600-64.macros
@@ -766,27 +766,27 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #define addInput(X, input, laneCount) \
     if (laneCount == 21) { \
-        X##ba ^= input[ 0]; \
-        X##be ^= input[ 1]; \
-        X##bi ^= input[ 2]; \
-        X##bo ^= input[ 3]; \
-        X##bu ^= input[ 4]; \
-        X##ga ^= input[ 5]; \
-        X##ge ^= input[ 6]; \
-        X##gi ^= input[ 7]; \
-        X##go ^= input[ 8]; \
-        X##gu ^= input[ 9]; \
-        X##ka ^= input[10]; \
-        X##ke ^= input[11]; \
-        X##ki ^= input[12]; \
-        X##ko ^= input[13]; \
-        X##ku ^= input[14]; \
-        X##ma ^= input[15]; \
-        X##me ^= input[16]; \
-        X##mi ^= input[17]; \
-        X##mo ^= input[18]; \
-        X##mu ^= input[19]; \
-        X##sa ^= input[20]; \
+        X##ba ^= HTOLE64(input[ 0]); \
+        X##be ^= HTOLE64(input[ 1]); \
+        X##bi ^= HTOLE64(input[ 2]); \
+        X##bo ^= HTOLE64(input[ 3]); \
+        X##bu ^= HTOLE64(input[ 4]); \
+        X##ga ^= HTOLE64(input[ 5]); \
+        X##ge ^= HTOLE64(input[ 6]); \
+        X##gi ^= HTOLE64(input[ 7]); \
+        X##go ^= HTOLE64(input[ 8]); \
+        X##gu ^= HTOLE64(input[ 9]); \
+        X##ka ^= HTOLE64(input[10]); \
+        X##ke ^= HTOLE64(input[11]); \
+        X##ki ^= HTOLE64(input[12]); \
+        X##ko ^= HTOLE64(input[13]); \
+        X##ku ^= HTOLE64(input[14]); \
+        X##ma ^= HTOLE64(input[15]); \
+        X##me ^= HTOLE64(input[16]); \
+        X##mi ^= HTOLE64(input[17]); \
+        X##mo ^= HTOLE64(input[18]); \
+        X##mu ^= HTOLE64(input[19]); \
+        X##sa ^= HTOLE64(input[20]); \
     } \
     else if (laneCount < 16) { \
         if (laneCount < 8) { \
@@ -795,165 +795,165 @@ http://creativecommons.org/publicdomain/zero/1.0/
                     if (laneCount < 1) { \
                     } \
                     else { \
-                        X##ba ^= input[ 0]; \
+                        X##ba ^= HTOLE64(input[ 0]); \
                     } \
                 } \
                 else { \
-                    X##ba ^= input[ 0]; \
-                    X##be ^= input[ 1]; \
+                    X##ba ^= HTOLE64(input[ 0]); \
+                    X##be ^= HTOLE64(input[ 1]); \
                     if (laneCount < 3) { \
                     } \
                     else { \
-                        X##bi ^= input[ 2]; \
+                        X##bi ^= HTOLE64(input[ 2]); \
                     } \
                 } \
             } \
             else { \
-                X##ba ^= input[ 0]; \
-                X##be ^= input[ 1]; \
-                X##bi ^= input[ 2]; \
-                X##bo ^= input[ 3]; \
+                X##ba ^= HTOLE64(input[ 0]); \
+                X##be ^= HTOLE64(input[ 1]); \
+                X##bi ^= HTOLE64(input[ 2]); \
+                X##bo ^= HTOLE64(input[ 3]); \
                 if (laneCount < 6) { \
                     if (laneCount < 5) { \
                     } \
                     else { \
-                        X##bu ^= input[ 4]; \
+                        X##bu ^= HTOLE64(input[ 4]); \
                     } \
                 } \
                 else { \
-                    X##bu ^= input[ 4]; \
-                    X##ga ^= input[ 5]; \
+                    X##bu ^= HTOLE64(input[ 4]); \
+                    X##ga ^= HTOLE64(input[ 5]); \
                     if (laneCount < 7) { \
                     } \
                     else { \
-                        X##ge ^= input[ 6]; \
+                        X##ge ^= HTOLE64(input[ 6]); \
                     } \
                 } \
             } \
         } \
         else { \
-            X##ba ^= input[ 0]; \
-            X##be ^= input[ 1]; \
-            X##bi ^= input[ 2]; \
-            X##bo ^= input[ 3]; \
-            X##bu ^= input[ 4]; \
-            X##ga ^= input[ 5]; \
-            X##ge ^= input[ 6]; \
-            X##gi ^= input[ 7]; \
+            X##ba ^= HTOLE64(input[ 0]); \
+            X##be ^= HTOLE64(input[ 1]); \
+            X##bi ^= HTOLE64(input[ 2]); \
+            X##bo ^= HTOLE64(input[ 3]); \
+            X##bu ^= HTOLE64(input[ 4]); \
+            X##ga ^= HTOLE64(input[ 5]); \
+            X##ge ^= HTOLE64(input[ 6]); \
+            X##gi ^= HTOLE64(input[ 7]); \
             if (laneCount < 12) { \
                 if (laneCount < 10) { \
                     if (laneCount < 9) { \
                     } \
                     else { \
-                        X##go ^= input[ 8]; \
+                        X##go ^= HTOLE64(input[ 8]); \
                     } \
                 } \
                 else { \
-                    X##go ^= input[ 8]; \
-                    X##gu ^= input[ 9]; \
+                    X##go ^= HTOLE64(input[ 8]); \
+                    X##gu ^= HTOLE64(input[ 9]); \
                     if (laneCount < 11) { \
                     } \
                     else { \
-                        X##ka ^= input[10]; \
+                        X##ka ^= HTOLE64(input[10]); \
                     } \
                 } \
             } \
             else { \
-                X##go ^= input[ 8]; \
-                X##gu ^= input[ 9]; \
-                X##ka ^= input[10]; \
-                X##ke ^= input[11]; \
+                X##go ^= HTOLE64(input[ 8]); \
+                X##gu ^= HTOLE64(input[ 9]); \
+                X##ka ^= HTOLE64(input[10]); \
+                X##ke ^= HTOLE64(input[11]); \
                 if (laneCount < 14) { \
                     if (laneCount < 13) { \
                     } \
                     else { \
-                        X##ki ^= input[12]; \
+                        X##ki ^= HTOLE64(input[12]); \
                     } \
                 } \
                 else { \
-                    X##ki ^= input[12]; \
-                    X##ko ^= input[13]; \
+                    X##ki ^= HTOLE64(input[12]); \
+                    X##ko ^= HTOLE64(input[13]); \
                     if (laneCount < 15) { \
                     } \
                     else { \
-                        X##ku ^= input[14]; \
+                        X##ku ^= HTOLE64(input[14]); \
                     } \
                 } \
             } \
         } \
     } \
     else { \
-        X##ba ^= input[ 0]; \
-        X##be ^= input[ 1]; \
-        X##bi ^= input[ 2]; \
-        X##bo ^= input[ 3]; \
-        X##bu ^= input[ 4]; \
-        X##ga ^= input[ 5]; \
-        X##ge ^= input[ 6]; \
-        X##gi ^= input[ 7]; \
-        X##go ^= input[ 8]; \
-        X##gu ^= input[ 9]; \
-        X##ka ^= input[10]; \
-        X##ke ^= input[11]; \
-        X##ki ^= input[12]; \
-        X##ko ^= input[13]; \
-        X##ku ^= input[14]; \
-        X##ma ^= input[15]; \
+        X##ba ^= HTOLE64(input[ 0]); \
+        X##be ^= HTOLE64(input[ 1]); \
+        X##bi ^= HTOLE64(input[ 2]); \
+        X##bo ^= HTOLE64(input[ 3]); \
+        X##bu ^= HTOLE64(input[ 4]); \
+        X##ga ^= HTOLE64(input[ 5]); \
+        X##ge ^= HTOLE64(input[ 6]); \
+        X##gi ^= HTOLE64(input[ 7]); \
+        X##go ^= HTOLE64(input[ 8]); \
+        X##gu ^= HTOLE64(input[ 9]); \
+        X##ka ^= HTOLE64(input[10]); \
+        X##ke ^= HTOLE64(input[11]); \
+        X##ki ^= HTOLE64(input[12]); \
+        X##ko ^= HTOLE64(input[13]); \
+        X##ku ^= HTOLE64(input[14]); \
+        X##ma ^= HTOLE64(input[15]); \
         if (laneCount < 24) { \
             if (laneCount < 20) { \
                 if (laneCount < 18) { \
                     if (laneCount < 17) { \
                     } \
                     else { \
-                        X##me ^= input[16]; \
+                        X##me ^= HTOLE64(input[16]); \
                     } \
                 } \
                 else { \
-                    X##me ^= input[16]; \
-                    X##mi ^= input[17]; \
+                    X##me ^= HTOLE64(input[16]); \
+                    X##mi ^= HTOLE64(input[17]); \
                     if (laneCount < 19) { \
                     } \
                     else { \
-                        X##mo ^= input[18]; \
+                        X##mo ^= HTOLE64(input[18]); \
                     } \
                 } \
             } \
             else { \
-                X##me ^= input[16]; \
-                X##mi ^= input[17]; \
-                X##mo ^= input[18]; \
-                X##mu ^= input[19]; \
+                X##me ^= HTOLE64(input[16]); \
+                X##mi ^= HTOLE64(input[17]); \
+                X##mo ^= HTOLE64(input[18]); \
+                X##mu ^= HTOLE64(input[19]); \
                 if (laneCount < 22) { \
                     if (laneCount < 21) { \
                     } \
                     else { \
-                        X##sa ^= input[20]; \
+                        X##sa ^= HTOLE64(input[20]); \
                     } \
                 } \
                 else { \
-                    X##sa ^= input[20]; \
-                    X##se ^= input[21]; \
+                    X##sa ^= HTOLE64(input[20]); \
+                    X##se ^= HTOLE64(input[21]); \
                     if (laneCount < 23) { \
                     } \
                     else { \
-                        X##si ^= input[22]; \
+                        X##si ^= HTOLE64(input[22]); \
                     } \
                 } \
             } \
         } \
         else { \
-            X##me ^= input[16]; \
-            X##mi ^= input[17]; \
-            X##mo ^= input[18]; \
-            X##mu ^= input[19]; \
-            X##sa ^= input[20]; \
-            X##se ^= input[21]; \
-            X##si ^= input[22]; \
-            X##so ^= input[23]; \
+            X##me ^= HTOLE64(input[16]); \
+            X##mi ^= HTOLE64(input[17]); \
+            X##mo ^= HTOLE64(input[18]); \
+            X##mu ^= HTOLE64(input[19]); \
+            X##sa ^= HTOLE64(input[20]); \
+            X##se ^= HTOLE64(input[21]); \
+            X##si ^= HTOLE64(input[22]); \
+            X##so ^= HTOLE64(input[23]); \
             if (laneCount < 25) { \
             } \
             else { \
-                X##su ^= input[24]; \
+                X##su ^= HTOLE64(input[24]); \
             } \
         } \
     }

--- a/lib/low/KeccakP-1600/Optimized64/KeccakP-1600-opt64.c
+++ b/lib/low/KeccakP-1600/Optimized64/KeccakP-1600-opt64.c
@@ -394,7 +394,7 @@ void KeccakP1600_ExtractBytesInLane(const void *state, unsigned int lanePosition
 /* ---------------------------------------------------------------- */
 
 #if (PLATFORM_BYTE_ORDER != IS_LITTLE_ENDIAN)
-void fromWordToBytes(UINT8 *bytes, const UINT64 word)
+static void fromWordToBytes(UINT8 *bytes, const UINT64 word)
 {
     unsigned int i;
 


### PR DESCRIPTION
`KeccakF1600_FastLoop_Absorb` does not change byte order of `data` as the other functions do. So `addInput` adds input to the state where the byte order is not correct.